### PR TITLE
compatibility: remove ngx_http_upstream_srv_conf_t.default_port

### DIFF
--- a/src/ngx_http_drizzle_upstream.c
+++ b/src/ngx_http_drizzle_upstream.c
@@ -1027,12 +1027,14 @@ ngx_http_upstream_drizzle_add(ngx_http_request_t *r, ngx_url_t *url)
             continue;
         }
 
+#if !defined(nginx_version) || nginx_version < 1011006
         if (uscfp[i]->default_port && url->default_port
             && uscfp[i]->default_port != url->default_port)
         {
             dd("upstream_add: default_port not match");
             continue;
         }
+#endif
 
         return uscfp[i];
     }


### PR DESCRIPTION
the default_port declaration was removed in this commit:
http://hg.nginx.org/nginx/rev/4dea01cf49e8

*unsure of consequences of this commit