### PR TITLE
fix potential null pointer dereference found by coverity

### DIFF
--- a/src/ngx_http_drizzle_upstream.c
+++ b/src/ngx_http_drizzle_upstream.c
@@ -887,7 +887,7 @@ ngx_http_upstream_drizzle_free_peer(ngx_peer_connection_t *pc,
         dd("after drizzle result free");
     }
 
-    if(pc){
+    if (pc != NULL) {
         if (dscf->max_cached) {
             ngx_http_drizzle_keepalive_free_peer(pc, dp, dscf, state);
         }

--- a/src/ngx_http_drizzle_upstream.c
+++ b/src/ngx_http_drizzle_upstream.c
@@ -887,18 +887,20 @@ ngx_http_upstream_drizzle_free_peer(ngx_peer_connection_t *pc,
         dd("after drizzle result free");
     }
 
-    if (dscf->max_cached) {
-        ngx_http_drizzle_keepalive_free_peer(pc, dp, dscf, state);
-    }
+    if(pc){
+        if (dscf->max_cached) {
+            ngx_http_drizzle_keepalive_free_peer(pc, dp, dscf, state);
+        }
 
-    if (pc && pc->connection) {
-        dd("actually free the drizzle connection");
+        if (pc->connection) {
+            dd("actually free the drizzle connection");
 
-        ngx_http_upstream_drizzle_free_connection(pc->log, pc->connection,
-                                                  dp->drizzle_con, dscf);
+            ngx_http_upstream_drizzle_free_connection(pc->log, pc->connection,
+                                                      dp->drizzle_con, dscf);
 
-        dp->drizzle_con = NULL;
-        pc->connection = NULL;
+            dp->drizzle_con = NULL;
+            pc->connection = NULL;
+        }
     }
 }
 


### PR DESCRIPTION
```
 890    if (dscf->max_cached) {
      CID 258033: Dereference after null check (FORWARD_NULL) [select issue]
    CID 258018 (#1 of 1): Dereference after null check (FORWARD_NULL)6. var_deref_model: Passing null pointer pc to ngx_http_drizzle_keepalive_free_peer, which dereferences it. [show details]
 891        ngx_http_drizzle_keepalive_free_peer(pc, dp, dscf, state);
 892    }
 893
 894    if (pc && pc->connection) {
 895        dd("actually free the drizzle connection");
 896
 897        ngx_http_upstream_drizzle_free_connection(pc->log, pc->connection,
 898                                                  dp->drizzle_con, dscf);
 899
 900        dp->drizzle_con = NULL;
 901        pc->connection = NULL;
 902    }
```