### PR TITLE
fix potential null pointer dereference found by coverity

### DIFF
--- a/src/ngx_http_drizzle_upstream.c
+++ b/src/ngx_http_drizzle_upstream.c
@@ -59,6 +59,9 @@ ngx_http_upstream_drizzle_create_srv_conf(ngx_conf_t *cf)
     conf->pool = cf->pool;
 
     cln = ngx_pool_cleanup_add(cf->pool, 0);
+    if (cln == NULL) {
+        return NULL;
+    }
 
     (void) drizzle_create(&conf->drizzle);
 


### PR DESCRIPTION
```
 63    (void) drizzle_create(&conf->drizzle);
 64
   CID 251600 (#1 of 1): Dereference null return value (NULL_RETURNS)4. dereference: Dereferencing cln, which is known to be NULL.
 65    cln->handler = ngx_http_upstream_drizzle_cleanup;
 66    cln->data = &conf->drizzle;
 67
```