### PR TITLE
bugfix: stash peer data in module ctx to survive upstream wrappers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ script:
   - cd ../luajit2
   - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUA_USE_APICHECK -DLUA_USE_ASSERT' > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)
+  - cpanm --sudo --notest Test::Nginx IPC::Run Test2::Util > build.log 2>&1 || (cat build.log && exit 1)
   - cd ..
   - cd test-nginx && sudo cpanm . && cd ..
   - export PATH=$PWD/work/nginx/sbin:$PWD/nginx-devel-utils:$PATH

--- a/src/ngx_http_drizzle_handler.c
+++ b/src/ngx_http_drizzle_handler.c
@@ -45,9 +45,7 @@ ngx_http_drizzle_handler(ngx_http_request_t *r)
 {
     ngx_http_upstream_t            *u;
     ngx_http_drizzle_loc_conf_t    *dlcf;
-#if defined(nginx_version) && nginx_version < 8017
     ngx_http_drizzle_ctx_t         *dctx;
-#endif
     ngx_http_core_loc_conf_t       *clcf;
     ngx_str_t                       target;
     ngx_url_t                       url;
@@ -145,14 +143,12 @@ ngx_http_drizzle_handler(ngx_http_request_t *r)
         }
     }
 
-#if defined(nginx_version) && nginx_version < 8017
     dctx = ngx_pcalloc(r->pool, sizeof(ngx_http_drizzle_ctx_t));
     if (dctx == NULL) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
     ngx_http_set_ctx(r, dctx, ngx_http_drizzle_module);
-#endif
 
     u->schema.len = sizeof("drizzle://") - 1;
     u->schema.data = (u_char *) "drizzle://";
@@ -363,7 +359,7 @@ ngx_http_drizzle_set_libdrizzle_ready(ngx_http_request_t *r)
     short                                        revents = 0;
 #endif
 
-    dp = r->upstream->peer.data;
+    dp = ngx_http_drizzle_get_peer_data(r);
 
     dc = dp->drizzle_con;
 

--- a/src/ngx_http_drizzle_module.h
+++ b/src/ngx_http_drizzle_module.h
@@ -87,11 +87,16 @@ typedef struct {
 } ngx_http_drizzle_loc_conf_t;
 
 
-#if defined(nginx_version) && (nginx_version < 8017)
 typedef struct {
+#if defined(nginx_version) && (nginx_version < 8017)
     ngx_int_t                           status;
-} ngx_http_drizzle_ctx_t;
 #endif
+    /* original drizzle peer data; saved here so handlers can find it
+     * even when r->upstream->peer.data has been wrapped by another
+     * module such as the standard upstream keepalive (which became
+     * implicit for explicit upstreams in nginx 1.29.7) */
+    void                               *peer_data;
+} ngx_http_drizzle_ctx_t;
 
 
 /* states for the drizzle client state machine */

--- a/src/ngx_http_drizzle_output.c
+++ b/src/ngx_http_drizzle_output.c
@@ -59,7 +59,7 @@ ngx_http_drizzle_output_result_header(ngx_http_request_t *r,
     uint16_t                         col_count;
     uint16_t                         errcode;
 
-    ngx_http_upstream_drizzle_peer_data_t   *dp = u->peer.data;
+    ngx_http_upstream_drizzle_peer_data_t   *dp = ngx_http_drizzle_get_peer_data(r);
 
     errcode = drizzle_result_error_code(res);
 
@@ -297,14 +297,13 @@ ngx_int_t
 ngx_http_drizzle_output_col(ngx_http_request_t *r, drizzle_column_st *col)
 {
     u_char                              *pos, *last;
-    ngx_http_upstream_t                 *u = r->upstream;
     drizzle_column_type_t                col_type = 0;
     uint16_t                             std_col_type = 0;
     const char                          *col_name = NULL;
     uint16_t                             col_name_len = 0;
     size_t                               size;
 
-    ngx_http_upstream_drizzle_peer_data_t   *dp = u->peer.data;
+    ngx_http_upstream_drizzle_peer_data_t   *dp = ngx_http_drizzle_get_peer_data(r);
 
     if (col == NULL) {
         return NGX_ERROR;
@@ -366,10 +365,9 @@ ngx_int_t
 ngx_http_drizzle_output_row(ngx_http_request_t *r, uint64_t row)
 {
     u_char                              *pos, *last;
-    ngx_http_upstream_t                 *u = r->upstream;
     size_t                               size;
 
-    ngx_http_upstream_drizzle_peer_data_t   *dp = u->peer.data;
+    ngx_http_upstream_drizzle_peer_data_t   *dp = ngx_http_drizzle_get_peer_data(r);
 
     size = sizeof(uint8_t);
 
@@ -394,10 +392,9 @@ ngx_http_drizzle_output_field(ngx_http_request_t *r, size_t offset,
     size_t len, size_t total, drizzle_field_t field)
 {
     u_char                              *pos, *last;
-    ngx_http_upstream_t                 *u = r->upstream;
     size_t                               size = 0;
 
-    ngx_http_upstream_drizzle_peer_data_t   *dp = u->peer.data;
+    ngx_http_upstream_drizzle_peer_data_t   *dp = ngx_http_drizzle_get_peer_data(r);
 
     if (offset == 0) {
 

--- a/src/ngx_http_drizzle_processor.c
+++ b/src/ngx_http_drizzle_processor.c
@@ -49,12 +49,9 @@ ngx_http_drizzle_process_events(ngx_http_request_t *r)
     u = r->upstream;
     c = u->peer.connection;
 
-    dp = u->peer.data;
+    dp = ngx_http_drizzle_get_peer_data(r);
 
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                   "drizzle process events, state: %d", dp->state);
-
-    if (!ngx_http_upstream_drizzle_is_my_peer(&u->peer)) {
+    if (dp == NULL) {
         ngx_log_error(NGX_LOG_ERR, c->log, 0,
                       "process events: it seems you "
                       "are using a non-drizzle upstream backend"
@@ -62,6 +59,9 @@ ngx_http_drizzle_process_events(ngx_http_request_t *r)
 
         return NGX_ERROR;
     }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "drizzle process events, state: %d", dp->state);
 
     dc = dp->drizzle_con;
 

--- a/src/ngx_http_drizzle_upstream.c
+++ b/src/ngx_http_drizzle_upstream.c
@@ -404,6 +404,7 @@ ngx_http_upstream_drizzle_init_peer(ngx_http_request_t *r,
     ngx_http_upstream_t                     *u;
     ngx_http_core_loc_conf_t                *clcf;
     ngx_http_drizzle_loc_conf_t             *dlcf;
+    ngx_http_drizzle_ctx_t                  *dctx;
     ngx_drizzle_mixed_t                     *query;
     ngx_str_t                                dbname, sql;
     ngx_uint_t                               i;
@@ -444,6 +445,14 @@ ngx_http_upstream_drizzle_init_peer(ngx_http_request_t *r,
     u->peer.data = dp;
     u->peer.get = ngx_http_upstream_drizzle_get_peer;
     u->peer.free = ngx_http_upstream_drizzle_free_peer;
+
+    /* Stash dp in the module ctx so handlers can recover it even if
+     * another module (e.g. the standard upstream keepalive, which is
+     * implicit in nginx 1.29.7+) wraps u->peer.data afterwards. */
+    dctx = ngx_http_get_module_ctx(r, ngx_http_drizzle_module);
+    if (dctx != NULL) {
+        dctx->peer_data = dp;
+    }
 
     /* prepare dbname */
 

--- a/src/ngx_http_drizzle_util.c
+++ b/src/ngx_http_drizzle_util.c
@@ -34,6 +34,24 @@ static void ngx_http_upstream_dbd_check_broken_connection(ngx_http_request_t *r,
     ngx_event_t *ev);
 
 
+void *
+ngx_http_drizzle_get_peer_data(ngx_http_request_t *r)
+{
+    ngx_http_drizzle_ctx_t  *dctx;
+
+    /* Prefer the ctx-saved pointer because r->upstream->peer.data may have
+     * been wrapped by the standard upstream keepalive (implicit since
+     * nginx 1.29.7) or by another balancer module. Fall back to peer.data
+     * for the rare case where the ctx is missing. */
+    dctx = ngx_http_get_module_ctx(r, ngx_http_drizzle_module);
+    if (dctx != NULL && dctx->peer_data != NULL) {
+        return dctx->peer_data;
+    }
+
+    return r->upstream ? r->upstream->peer.data : NULL;
+}
+
+
 ngx_int_t
 ngx_http_drizzle_set_header(ngx_http_request_t *r, ngx_str_t *key,
     ngx_str_t *value)
@@ -1033,7 +1051,7 @@ ngx_http_drizzle_set_thread_id_variable(ngx_http_request_t *r,
 
     ngx_http_upstream_drizzle_peer_data_t       *dp;
 
-    dp = r->upstream->peer.data;
+    dp = ngx_http_drizzle_get_peer_data(r);
     if (dp == NULL) {
         return NGX_ERROR;
     }

--- a/src/ngx_http_drizzle_util.h
+++ b/src/ngx_http_drizzle_util.h
@@ -15,6 +15,9 @@
 #endif
 
 
+/* Returns the drizzle peer-data pointer (ngx_http_upstream_drizzle_peer_data_t *).
+ * Returns void * to avoid pulling ngx_http_drizzle_upstream.h here. */
+void *ngx_http_drizzle_get_peer_data(ngx_http_request_t *r);
 void ngx_http_upstream_dbd_init(ngx_http_request_t *r);
 void ngx_http_upstream_dbd_init_request(ngx_http_request_t *r);
 ngx_int_t ngx_http_drizzle_set_header(ngx_http_request_t *r, ngx_str_t *key,


### PR DESCRIPTION
Since nginx 1.29.7 (commit 4fbe4b62, "Upstream: enabled keepalive by default for explicit upstreams.") the standard upstream keepalive module implicitly wraps every explicit upstream in "local" keepalive mode. Its init_peer overwrites r->upstream->peer.data with its own ~64-byte ngx_http_upstream_keepalive_peer_data_t after our init_peer returns.

Our event handlers (ngx_http_drizzle_set_libdrizzle_ready, ngx_http_drizzle_process_events, set_thread_id_variable, and the output_* helpers) re-read r->upstream->peer.data and cast it back to ngx_http_upstream_drizzle_peer_data_t (~9256 bytes). With the keepalive wrapper in place, dp->drizzle_con reads past the end of the wrapper struct and returns garbage; dereferencing it segfaults the worker, e.g.

    ngx_http_drizzle_set_libdrizzle_ready (...drizzle_handler.c:389)
        dc->options |= DRIZZLE_CON_IO_READY;   // dc == 0x21

Save the original drizzle peer-data pointer in the module ctx in init_peer, and add a small helper ngx_http_drizzle_get_peer_data() that returns the ctx-saved pointer (falling back to peer.data when no ctx is set). All consumers that previously read u->peer.data now go through the helper. The ngx_http_drizzle_ctx_t struct is now defined for all nginx versions (it was previously only built for nginx_version < 8017).

While here, replace the ngx_http_upstream_drizzle_is_my_peer() probe in process_events with a NULL check on dp; the old probe compared peer->get against ngx_http_upstream_drizzle_get_peer and would always report a non-drizzle backend once the keepalive wrapper installs its own get function.